### PR TITLE
fix endless loop during release pdu session

### DIFF
--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -250,7 +250,7 @@ func HandlePDUSessionSMContextUpdate(rspChan chan smf_message.HandlerResponseMes
 			for _, dataPath := range smContext.Tunnel.DataPathPool {
 
 				dataPath.DeactivateTunnelAndPDR(smContext)
-				for curDataPathNode := dataPath.FirstDPNode; curDataPathNode != nil; curDataPathNode.Next() {
+				for curDataPathNode := dataPath.FirstDPNode; curDataPathNode != nil; curDataPathNode = curDataPathNode.Next() {
 					curUPFID, _ := curDataPathNode.GetUPFID()
 					if _, exist := deletedPFCPNode[curUPFID]; !exist {
 						seqNum = pfcp_message.SendPfcpSessionDeletionRequest(curDataPathNode.UPF.NodeID, smContext)


### PR DESCRIPTION
During releasing PDU Session， handing channel message，HandlePDUSessionSMContextRelease will not return， Because of endless loop with curDataPathNode.Next() always true. 
Other messages in channel will block， which failed to handle PFCP message， failed to handle message from AMF.
sequential processing channel message will block